### PR TITLE
Pushlist fixes lander

### DIFF
--- a/StartspelerApp/jsApp/src/main/kotlin/com/startspeler/js/OrderEditPage.kt
+++ b/StartspelerApp/jsApp/src/main/kotlin/com/startspeler/js/OrderEditPage.kt
@@ -104,7 +104,7 @@ val OrderEditPage = FC<OrderEditPageProps> { props ->
                 } catch (_: Throwable) {}
 
                 try {
-                    val klantenRes = window.fetch(b.trimEnd('/') + "/klanten").await()
+                    val klantenRes = window.fetch(b.trimEnd('/') + "/klanten/names").await()
                     if (klantenRes.ok) {
                         val klantenText = klantenRes.text().await()
                         val klantenList = json.decodeFromString<List<String>>(klantenText)

--- a/StartspelerApp/server/src/main/kotlin/startspeler/server/routes/TafelRoutes.kt
+++ b/StartspelerApp/server/src/main/kotlin/startspeler/server/routes/TafelRoutes.kt
@@ -17,9 +17,11 @@ import io.ktor.server.request.receive
 fun Routing.tafelRoutes() {
     route("/tafels") {
         get {
-            // Return all tafel numbers as strings (e.g. "Tafel 1")
             val tafels = transaction {
-                TableModel.selectAll().map { "Tafel ${it[TableModel.number]}" }
+                TafelRepository.getAll()
+                    .filterNot { it.statusName.equals("inactief", ignoreCase = true) }
+                    .sortedBy { it.number }
+                    .map { "Tafel ${it.number}" }
             }
             call.respond(tafels)
         }


### PR DESCRIPTION
Fixes van:
- Klanten ophalen voor bestellingen scherm werkt niet meer [ ]
- Ophalen klanten bij aanpassen bestelling niet mee opgehaald en ingevuld. Oplossing is zelfde als aanpassingen voor klanten ophalen in algemeen bestel scherm [ ]
- Tafels die inactief zijn worden nog getoont in lijst van bestellingen [ ]